### PR TITLE
ULIGA-176 비밀번호 초기화, 재설정 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -40,3 +40,8 @@ export const authSocialLogin = async (userData: object) => {
   const { data } = await unAuthorizationClient.post(API.SOCIAL_LOGIN, userData);
   return data;
 };
+
+export const authResetPassword = async (email: object) => {
+  const { data } = await unAuthorizationClient.post(API.RESET_PASSWORD, email);
+  return data;
+};

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -64,5 +64,6 @@ const API = {
   SOCIAL_LOGIN: `${AUTH}social-login`,
   KAKAO_AUTH_URL: `${BASE_URL}/oauth2/authorization/kakao?redirect_uri=http://localhost:3000`,
   GOOGLE_AUTH_URL: `${BASE_URL}/oauth2/authorization/google?redirect_uri=http://localhost:3000`,
+  RESET_PASSWORD: `${AUTH}password/reset`,
 };
 export default API;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -10,7 +10,7 @@ type ButtonTheme =
   | "quaternary"
   | "basic";
 type ButtonSize = "large" | "medium" | "small";
-type ButtonType = "button" | "submit" | "reset";
+type ButtonType = "button" | "submit" | "reset" | undefined;
 type ButtonProps = {
   /** 버튼 안의 내용 */
   title?: string;

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -30,6 +30,7 @@ type IconButtonProps = {
   /** icon, text 위치 반전 */
   reverseIconButton?: boolean;
   dataCy?: string;
+  type?: "submit" | "button" | "reset" | undefined;
 };
 
 export default function IconButton({
@@ -46,6 +47,7 @@ export default function IconButton({
   className,
   reverseIconButton = false,
   dataCy = "",
+  type,
 }: IconButtonProps) {
   return (
     <Wrapper
@@ -57,6 +59,7 @@ export default function IconButton({
       disabled={disabled}
       reverseIconButton={reverseIconButton}
       data-cy={dataCy}
+      type={type}
     >
       {reverseIconButton === false ? (
         <>

--- a/src/hooks/book/useMe.ts
+++ b/src/hooks/book/useMe.ts
@@ -1,19 +1,116 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useRecoilState } from "recoil";
 import { useNavigate } from "react-router-dom";
 import toastMsg from "../../components/Toast";
 import QUERYKEYS from "../../constants/querykey";
 import useInput from "../useInput";
-import { deleteMe, patchMe } from "../../api/user";
+import { deleteMe, loadMe, patchMe } from "../../api/user";
 import { checkNicknameDuplicate } from "../../api/auth";
+import { IUserInfo } from "../../interfaces/user";
+import { deleteScheduleDialogAtom } from "../../stores/atoms/context";
+import useValidate from "../useValidate";
+import REGEX from "../../constants/regex";
 
 export default function useMe() {
   const queryClient = useQueryClient();
-  const [nickName, onChangeNickname] = useInput("");
+  const [password, onChangePassword, , isValidatePassword] = useValidate({
+    validator: (input: string) => REGEX.PASSWORD.test(input),
+  });
+  const [passwordCheck, onChangePasswordCheck] = useInput("");
+  const [applicationPassword, onChangeApplicationPassword] = useInput("123456");
+  const [isPasswordVisible, setIsPasswordVisible] = useState({
+    password: false,
+    passwordCheck: false,
+    applicationPassword: false,
+  });
+  const [deleteDialogOpen, setDeleteDialogOpen] = useRecoilState(
+    deleteScheduleDialogAtom,
+  );
   const navigate = useNavigate();
 
-  const mutateUpdateNickname = useMutation(["patchMe"], patchMe, {
+  const { isLoading: loadingInfo, data: infoData } = useQuery<
+    IUserInfo | undefined
+  >([QUERYKEYS.LOAD_ME], loadMe);
+  const [nickName, onChangeNickname] = useInput(infoData?.memberInfo.nickName);
+
+  const inputs = [
+    {
+      label: "사용자 이메일",
+      value: infoData?.memberInfo.email,
+      readOnly: true,
+    },
+    {
+      label: "사용자 이름",
+      value: infoData?.memberInfo.userName,
+      readOnly: true,
+    },
+    {
+      label: "사용자 닉네임",
+      value: nickName,
+      placeholder: infoData?.memberInfo.nickName,
+      readOnly: false,
+      onChange: onChangeNickname,
+    },
+    {
+      label: "비밀번호",
+      value: password,
+      type: isPasswordVisible.password ? "text" : "password",
+      onChange: onChangePassword,
+      message:
+        !isValidatePassword && password.length > 0
+          ? "영문, 숫자, 특수문자를 3가지 이상으로 조합해 8자 이상 16자 이하 입력해주세요."
+          : "",
+      visible: isPasswordVisible.password,
+    },
+    {
+      label: "비밀번호 확인",
+      value: passwordCheck,
+      type: isPasswordVisible.passwordCheck ? "text" : "password",
+      onChange: onChangePasswordCheck,
+      message:
+        password !== passwordCheck && password.length > 0
+          ? "비밀번호가 일치하지 않습니다."
+          : "",
+      visible: isPasswordVisible.passwordCheck,
+    },
+    {
+      label: "애플리케이션 비밀번호",
+      value: applicationPassword,
+      type: isPasswordVisible.applicationPassword ? "text" : "password",
+      onChange: onChangeApplicationPassword,
+      visible: isPasswordVisible.applicationPassword,
+    },
+  ];
+
+  const lookPassword = (label: string) => {
+    switch (label) {
+      case "비밀번호":
+        setIsPasswordVisible({
+          ...isPasswordVisible,
+          password: !isPasswordVisible.password,
+        });
+        break;
+      case "비밀번호 확인":
+        setIsPasswordVisible({
+          ...isPasswordVisible,
+          passwordCheck: !isPasswordVisible.passwordCheck,
+        });
+        break;
+      case "애플리케이션 비밀번호":
+        setIsPasswordVisible({
+          ...isPasswordVisible,
+          applicationPassword: !isPasswordVisible.applicationPassword,
+        });
+        break;
+      default:
+        break;
+    }
+  };
+
+  const mutateUpdateMe = useMutation(["patchMe"], patchMe, {
     onSuccess: () => {
-      toastMsg("닉네임 변경 완료");
+      toastMsg("내 정보 변경 완료");
       queryClient.invalidateQueries([QUERYKEYS.LOAD_ME]);
     },
     onError: ({
@@ -26,11 +123,18 @@ export default function useMe() {
   });
   const checkNickname = async () => {
     const data = await checkNicknameDuplicate(nickName);
-    if (!data.exists) {
+    if (!data.exists || nickName === infoData?.memberInfo.nickName) {
       toastMsg("사용 가능한 닉네임 입니다.");
-      mutateUpdateNickname.mutate({
-        nickName,
-      });
+      mutateUpdateMe.mutate(
+        password.length > 0
+          ? {
+              nickName,
+              password,
+            }
+          : {
+              nickName,
+            },
+      );
     } else {
       toastMsg("이미 존재하는 닉네임입니다.");
     }
@@ -46,23 +150,18 @@ export default function useMe() {
       console.log(err);
     }
   };
-  const passwordInput = document.getElementById("password") as HTMLInputElement;
-  const showPasswordBtn = document.getElementById("show-password");
 
-  showPasswordBtn?.addEventListener("click", () => {
-    if (passwordInput.type === "password") {
-      passwordInput.type = "text";
-    } else {
-      passwordInput.type = "password";
-    }
-  });
-  const lookPassword = async () => {};
   return {
-    mutateUpdateNickname,
-    nickName,
-    onChangeNickname,
+    loadingInfo,
+    infoData,
+    inputs,
     checkNickname,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
     deleteUser,
     lookPassword,
+    isValidatePassword,
+    password,
+    passwordCheck,
   };
 }

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,20 +1,28 @@
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
 import { useState } from "react";
 import useInput from "./useInput";
 import REGEX from "../constants/regex";
-import { authLogin, checkEmail } from "../api/auth";
+import { authLogin, authResetPassword, checkEmail } from "../api/auth";
 import toastMsg from "../components/Toast";
 import PATH from "../constants/path";
 import useValidate from "./useValidate";
+import { resetPasswordDialogAtom } from "../stores/atoms/context";
 
 export default function useLogin() {
   const navigate = useNavigate();
+  const { state } = useLocation();
   const [email, onChangeEmail, , isValidateEmail] = useValidate({
     validator: (input: string) => REGEX.ID.test(input),
+    initState: state,
   });
   const [password, onChangePassword] = useInput("");
   const [loginType, setLoginType] = useState("");
+  const [resetPasswordDialogOpen, setResetPasswordDialogOpen] = useRecoilState(
+    resetPasswordDialogAtom,
+  );
+
   const mutateLogin = useMutation(["login"], authLogin, {
     onSuccess: ({ memberInfo, tokenInfo }) => {
       toastMsg("로그인 성공 👏");
@@ -35,6 +43,13 @@ export default function useLogin() {
     },
   });
 
+  const onClickResetPassword = () => {
+    authResetPassword({ email: state }).then(() => {
+      toastMsg("해당 이메일로 비밀번호 초기화 메일을 전송했습니다.");
+      setResetPasswordDialogOpen(false);
+    });
+  };
+
   const [landingEmail, onChangeLandingEmail] = useInput("");
 
   const mutateCheckEmail = useMutation(["checkEmail"], checkEmail, {
@@ -44,7 +59,7 @@ export default function useLogin() {
           toastMsg(
             "가입되어 있는 계정이 존재하므로 로그인 페이지로 이동합니다.",
           );
-          navigate(PATH.LOGIN);
+          navigate(PATH.LOGIN, { state: landingEmail });
         } else if (data.loginType === "GOOGLE") {
           setLoginType("GOOGLE");
         } else if (data.loginType === "KAKAO") {
@@ -75,5 +90,9 @@ export default function useLogin() {
     onChangeLandingEmail,
     mutateCheckEmail,
     loginType,
+    resetPasswordDialogOpen,
+    setResetPasswordDialogOpen,
+    onClickResetPassword,
+    state,
   };
 }

--- a/src/pages/login/index.styles.tsx
+++ b/src/pages/login/index.styles.tsx
@@ -8,7 +8,7 @@ const Container = styled.form`
   display: flex;
   flex-direction: column;
   width: 46.5rem;
-  height: 45rem;
+  height: 45.5rem;
   position: relative;
   gap: 4rem;
   padding-top: 2rem;
@@ -40,7 +40,7 @@ const Title = styled.div`
 
 const StyledButton = styled(Button)`
   font-size: 1.4rem;
-  padding: 1.2rem 1rem;
+  padding: 1.4rem 1rem;
   border-radius: 0.7rem;
   position: absolute;
   right: 0;

--- a/src/pages/login/index.styles.tsx
+++ b/src/pages/login/index.styles.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import COLORS from "../../constants/color";
 import Button from "../../components/Button";
 import media from "../../styles/media";
+import IconButton from "../../components/IconButton";
 
 const Container = styled.form`
   display: flex;
@@ -49,4 +50,11 @@ const StyledButton = styled(Button)`
   }
 `;
 
-export { Container, LogoWrapper, Title, StyledButton };
+const PasswordResetButton = styled(IconButton)`
+  font-size: 1.3rem;
+  position: absolute;
+  right: 0;
+  bottom: -4rem;
+`;
+
+export { Container, LogoWrapper, Title, StyledButton, PasswordResetButton };

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -3,6 +3,7 @@ import Logo from "../../assets/logo";
 import Input from "../../components/Input";
 import useLogin from "../../hooks/useLogin";
 import * as S from "./index.styles";
+import Dialog from "../../components/Dialog";
 
 export default function Login() {
   const {
@@ -12,6 +13,10 @@ export default function Login() {
     password,
     onChangePassword,
     mutateLogin,
+    resetPasswordDialogOpen,
+    setResetPasswordDialogOpen,
+    state,
+    onClickResetPassword,
   } = useLogin();
 
   const inputList = [
@@ -21,6 +26,7 @@ export default function Login() {
       label: "이메일 주소",
       value: email,
       onChange: onChangeEmail,
+      readOnly: true,
       placeholder: "이메일 주소를 입력해주세요.",
       message:
         !isValidateEmail && email.length > 0
@@ -59,15 +65,43 @@ export default function Login() {
             onChange={input.onChange}
             placeholder={input.placeholder}
             message={input.message}
+            readOnly={input.readOnly}
           />
         </div>
       ))}
       <S.StyledButton
         type="submit"
         title="로그인"
-        width="13.5rem"
+        width="100%"
         disabled={email.length <= 0 || password.length <= 0 || !isValidateEmail}
       />
+      <S.PasswordResetButton
+        type="button"
+        title="비밀번호 초기화"
+        iconName="arrowRight"
+        border={1}
+        iconSize="1.1rem"
+        theme="normal"
+        reverseIconButton
+        onClick={() => {
+          setResetPasswordDialogOpen(true);
+        }}
+      />
+      {resetPasswordDialogOpen && (
+        <Dialog
+          size={47}
+          title="💁🏻‍♀️ 비밀번호 초기화 메일 전송"
+          description={`${state}으로 새로운 비밀번호를 보내드릴게요. 
+          * 내 정보 페이지에서 원하시는 비밀번호로 설정하실 수 있어요.`}
+          cancellable
+          visible
+          onCancel={() => {
+            setResetPasswordDialogOpen(false);
+          }}
+          onConfirm={onClickResetPassword}
+          confirmTitle="전송"
+        />
+      )}
     </S.Container>
   );
 }

--- a/src/stores/atoms/context.ts
+++ b/src/stores/atoms/context.ts
@@ -70,3 +70,8 @@ export const historyDayModalAtom = atom<boolean>({
   key: "historyDayModalAtom",
   default: false,
 });
+
+export const resetPasswordDialogAtom = atom<boolean>({
+  key: "resetPasswordDialogAtom",
+  default: false,
+});


### PR DESCRIPTION
## Description
### - 랜딩 페이지에서 이메일을 입력하면 로그인 페이지에서 비밀번호 초기화를 진행할 수 있습니다.

![image](https://github.com/Uliga/Uliga_Frontend/assets/79246447/2970ddf5-f5a2-4c0b-8b85-d1802913925b)

<br/>

### - 전송 버튼을 누르면 초기화 메일이 전송됩니다.

<br/>

![image](https://github.com/Uliga/Uliga_Frontend/assets/79246447/fbb9b9ef-d985-4e85-82f4-7e2f7ff012e2)

<br/>

### - 새로운 비밀번호가 해당 메일로 전송됩니다.

<br/>

![image](https://github.com/Uliga/Uliga_Frontend/assets/79246447/1932c59a-7160-4d1e-a3b7-030f710ff562)

<br/>

### - 내 정보 설정 페이지에서는 닉네임만! 변경할 수도 있고, 비밀번호와 닉네임 모두 변경하는것도 가능합니다.

<br/>

![image](https://github.com/Uliga/Uliga_Frontend/assets/79246447/db7d680c-491a-49cd-9da7-c0fd9b298261)


